### PR TITLE
Add Alfred to list of applications

### DIFF
--- a/index.md
+++ b/index.md
@@ -68,6 +68,7 @@ These applications support all or some of the universal and/or proprietary ident
 |Application|URL|Notes|
 |---|---|---|
 |1Password |https://1password.com ||
+|Alfred |https://www.alfredapp.com ||
 |Butler |https://manytricks.com/butler |1|
 |ClipBook|https://clipbook.app||
 |CopyPaste Pro |https://plumamazing.com/product/copypaste-pro-for-mac/ ||
@@ -104,6 +105,7 @@ If your application is not listed or your application is listed and you’d like
 * Dec 4, 2024: Adds Enpass to List of Apps.
 * Apr 16, 2025: Adds Grammarly for Mac.
 * Apr 17, 2025: Adds "com.apple.is-remote-clipboard" identifier and ClipbBook app.
+* Jun 9, 2025: Adds Alfred.
 
 ## Contact
 


### PR DESCRIPTION
Alfred has supported these options in its Clipboard History for close to a decade, with the option to ignore or not (enabled by default) in addition to a prepopulated and editable list of apps to ignore regardless.

<img width="648" alt="image" src="https://github.com/user-attachments/assets/e3b3e30e-7c1d-405b-833e-d8aa7bfe452a" />

I’ve also added a changelog line, but feel free to directly edit the date or message if you merge at a later point or it doesn’t fit the page’s style for some reason.